### PR TITLE
Add a simple launch file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,7 @@ link_directories(
 
 add_subdirectory(src)
 
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
+install(
+  DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)

--- a/launch/choreonoid.launch
+++ b/launch/choreonoid.launch
@@ -1,0 +1,5 @@
+<launch>
+  <arg name="choreonoid_arg"/>
+  <node name="choreonoid" pkg="choreonoid_ros" type="choreonoid"
+        args="$(arg choreonoid_arg)" output="screen"/>
+</launch>


### PR DESCRIPTION
簡素なlaunchファイルを追加しました．
これにより，
```bash
roslaunch choreonoid_ros choreonoid.launch
```
の実行で，ROSコアを別ターミナルで立ち上げることなく起動が可能になります．
また他のパッケージからの呼び出し起動も容易になります．

引数`choreonoid_arg`を指定することで，単独立ち上げのオプションも使えるようにしています．
e.g.:
```
roslaunch choreonoid_ros choreonoid.launch choreonoid_arg:=<PATH_TO_CHOREONOID>/sample/SimpleController/SR1Walk.cnoid
```