### PR TITLE
Remove launch installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,3 @@ link_directories(
   )
 
 add_subdirectory(src)
-
-install(
-  DIRECTORY launch/
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
-)


### PR DESCRIPTION
#1 で加筆したlaunchのインストールが不要であり，これを残しておくと逆にファイルがコピーされ正常にlaunchの場所を特定できなくなることがわかりました．

```
RLException: multiple files named [choreonoid.launch] in package [choreonoid_ros]:
```

本PRにてこれを修正しています．