### PR TITLE
Set a default argument on choreonoid launch

### DIFF
--- a/launch/choreonoid.launch
+++ b/launch/choreonoid.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="choreonoid_arg"/>
+  <arg name="choreonoid_arg" default=""/>
   <node name="choreonoid" pkg="choreonoid_ros" type="choreonoid"
         args="$(arg choreonoid_arg)" output="screen"/>
 </launch>


### PR DESCRIPTION
こちらも #1 で対応しきれていなかった不備の修正です．
```bash
roslaunch choreonoid_ros choreonoid.launch
```
のように引数なしで立ち上げようとするときに，引数がセットされていないことを理由に失敗する現象が確認されました．
これに対応するために，デフォルト値を空文字列で与えてるようにしています．
