### PR TITLE
Compiles against official choreonoid and export package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   choreonoid
   )
 
-# find_package(Qt5 COMPONENTS Widgets REQUIRED)
-
-catkin_package(SKIP_CMAKE_CONFIG_GENERATION SKIP_PKG_CONFIG_GENERATION)
+catkin_package()
 
 if(CHOREONOID_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD ${CHOREONOID_CXX_STANDARD})

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,8 @@
   <url type="website">http://choreonoid.org</url>
   <url type="repository">https://github.com/choreonoid/choreonoid_ros_samples.git</url>
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>choreonoid</depend>
+  <build_depend version_gte="1.8.1">choreonoid</build_depend>
+  <exec_depend version_gte="1.8.1">choreonoid</exec_depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
This PR is related to https://github.com/choreonoid/choreonoid/pull/5:
- It ensures that `choreonoid_ros` links against the official choreonoid master (`>= 1.8.1`)
- It exports the (empty) `choreonoid_ros` package such that downstream packages can know whether choreonoid has ros support
```
find_package(choreonoid_ros QUIET)
if(${choreonoid_ros_FOUND})
  # do specific things if choreonoid has ros (install ROS-specific project files, etc)
endif()
```