### PR TITLE
Use reservation instead of resizing to initialize publisher vectors

### DIFF
--- a/src/plugin/BodyROSItem.cpp
+++ b/src/plugin/BodyROSItem.cpp
@@ -157,9 +157,9 @@ void BodyROSItem::createSensors(BodyPtr body)
         std::replace(name.begin(), name.end(), '-', '_');
         const ros::Publisher publisher
             = rosnode_->advertise<geometry_msgs::WrenchStamped>(name, 1);
-        sensor->sigStateChanged().connect(
-            boost::bind(&BodyROSItem::updateForceSensor,
-                        this, sensor, publisher));
+        sensor->sigStateChanged().connect([this, sensor, publisher]() {
+            updateForceSensor(sensor, publisher);
+        });
         force_sensor_publishers_.push_back(publisher);
         boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
             = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
@@ -176,9 +176,9 @@ void BodyROSItem::createSensors(BodyPtr body)
         std::replace(name.begin(), name.end(), '-', '_');
         const ros::Publisher publisher
             = rosnode_->advertise<sensor_msgs::Imu>(name, 1);
-        sensor->sigStateChanged().connect(
-            boost::bind(&BodyROSItem::updateRateGyroSensor,
-                        this, sensor, publisher));
+        sensor->sigStateChanged().connect([this, sensor, publisher]() {
+            updateRateGyroSensor(sensor, publisher);
+        });
         rate_gyro_sensor_publishers_.push_back(publisher);
         boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
             = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
@@ -195,9 +195,9 @@ void BodyROSItem::createSensors(BodyPtr body)
         std::replace(name.begin(), name.end(), '-', '_');
         const ros::Publisher publisher
             = rosnode_->advertise<sensor_msgs::Imu>(name, 1);
-        sensor->sigStateChanged().connect(
-            boost::bind(&BodyROSItem::updateAccelSensor,
-                        this, sensor, publisher));
+        sensor->sigStateChanged().connect([this, sensor, publisher]() {
+            updateAccelSensor(sensor, publisher);
+        });
         accel_sensor_publishers_.push_back(publisher);
         boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
             = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
@@ -215,9 +215,9 @@ void BodyROSItem::createSensors(BodyPtr body)
         std::replace(name.begin(), name.end(), '-', '_');
         const image_transport::Publisher publisher
             = it.advertise(name + "/image_raw", 1);
-        sensor->sigStateChanged().connect(
-            boost::bind(&BodyROSItem::updateVisionSensor,
-                        this, sensor, publisher));
+        sensor->sigStateChanged().connect([this, sensor, publisher]() {
+            updateVisionSensor(sensor, publisher);
+        });
         vision_sensor_publishers_.push_back(publisher);
         boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
             = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
@@ -235,9 +235,9 @@ void BodyROSItem::createSensors(BodyPtr body)
         std::replace(name.begin(), name.end(), '-', '_');
         const ros::Publisher publisher = rosnode_->advertise<
             sensor_msgs::PointCloud2>(name + "/point_cloud", 1);
-        sensor->sigStateChanged().connect(
-            boost::bind(&BodyROSItem::updateRangeVisionSensor,
-                        this, sensor, publisher));
+        sensor->sigStateChanged().connect([this, sensor, publisher]() {
+            updateRangeVisionSensor(sensor, publisher);
+        });
         range_vision_sensor_publishers_.push_back(publisher);
         // adds a server only for the camera whose type is COLOR_DEPTH or POINT_CLOUD.
         // Without this exception, a new service server may be a duplicate
@@ -266,9 +266,9 @@ void BodyROSItem::createSensors(BodyPtr body)
             std::replace(name.begin(), name.end(), '-', '_');
             const ros::Publisher publisher = rosnode_->advertise<
                 sensor_msgs::PointCloud>(name + "/point_cloud", 1);
-            sensor->sigStateChanged().connect(
-                boost::bind(&BodyROSItem::update3DRangeSensor,
-                            this, sensor, publisher));
+            sensor->sigStateChanged().connect([this, sensor, publisher]() {
+                update3DRangeSensor(sensor, publisher);
+            });
             range_sensor_pc_publishers_.push_back(publisher);
             boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
                 = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
@@ -281,9 +281,9 @@ void BodyROSItem::createSensors(BodyPtr body)
             std::replace(name.begin(), name.end(), '-', '_');
             const ros::Publisher publisher
                 = rosnode_->advertise<sensor_msgs::LaserScan>(name + "/scan", 1);
-            sensor->sigStateChanged().connect(
-                boost::bind(&BodyROSItem::updateRangeSensor,
-                            this, sensor, publisher));
+            sensor->sigStateChanged().connect([this, sensor, publisher]() {
+                updateRangeSensor(sensor, publisher);
+            });
             range_sensor_publishers_.push_back(publisher);
             boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
                 = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
@@ -321,7 +321,8 @@ bool BodyROSItem::control()
 }
 
 
-void BodyROSItem::updateForceSensor(ForceSensor* sensor, ros::Publisher& publisher)
+void BodyROSItem::updateForceSensor(const ForceSensorPtr& sensor,
+                                    const ros::Publisher& publisher)
 {
     geometry_msgs::WrenchStamped force;
     force.header.stamp.fromSec(io->currentTime());
@@ -336,7 +337,8 @@ void BodyROSItem::updateForceSensor(ForceSensor* sensor, ros::Publisher& publish
 }
 
 
-void BodyROSItem::updateRateGyroSensor(RateGyroSensor* sensor, ros::Publisher& publisher)
+void BodyROSItem::updateRateGyroSensor(const RateGyroSensorPtr& sensor,
+                                       const ros::Publisher& publisher)
 {
     sensor_msgs::Imu gyro;
     gyro.header.stamp.fromSec(io->currentTime());
@@ -348,7 +350,8 @@ void BodyROSItem::updateRateGyroSensor(RateGyroSensor* sensor, ros::Publisher& p
 }
 
 
-void BodyROSItem::updateAccelSensor(AccelerationSensor* sensor, ros::Publisher& publisher)
+void BodyROSItem::updateAccelSensor(const AccelerationSensorPtr& sensor,
+                                    const ros::Publisher& publisher)
 {
     sensor_msgs::Imu accel;
     accel.header.stamp.fromSec(io->currentTime());
@@ -360,7 +363,8 @@ void BodyROSItem::updateAccelSensor(AccelerationSensor* sensor, ros::Publisher& 
 }
 
 
-void BodyROSItem::updateVisionSensor(Camera* sensor, image_transport::Publisher& publisher)
+void BodyROSItem::updateVisionSensor(const CameraPtr& sensor,
+                                     const image_transport::Publisher& publisher)
 {
     sensor_msgs::Image vision;
     vision.header.stamp.fromSec(io->currentTime());
@@ -382,7 +386,8 @@ void BodyROSItem::updateVisionSensor(Camera* sensor, image_transport::Publisher&
 }
 
 
-void BodyROSItem::updateRangeVisionSensor(RangeCamera* sensor, ros::Publisher& publisher)
+void BodyROSItem::updateRangeVisionSensor(const RangeCameraPtr& sensor,
+                                          const ros::Publisher& publisher)
 {
     sensor_msgs::PointCloud2 range;
     range.header.stamp.fromSec(io->currentTime());
@@ -452,7 +457,8 @@ void BodyROSItem::updateRangeVisionSensor(RangeCamera* sensor, ros::Publisher& p
 }
 
 
-void BodyROSItem::updateRangeSensor(RangeSensor* sensor, ros::Publisher& publisher)
+void BodyROSItem::updateRangeSensor(const RangeSensorPtr& sensor,
+                                    const ros::Publisher& publisher)
 {
     sensor_msgs::LaserScan range;
     range.header.stamp.fromSec(io->currentTime());
@@ -479,7 +485,8 @@ void BodyROSItem::updateRangeSensor(RangeSensor* sensor, ros::Publisher& publish
 }
 
 
-void BodyROSItem::update3DRangeSensor(RangeSensor* sensor, ros::Publisher& publisher)
+void BodyROSItem::update3DRangeSensor(const RangeSensorPtr& sensor,
+                                      const ros::Publisher& publisher)
 {
     sensor_msgs::PointCloud range;
     // Header Info

--- a/src/plugin/BodyROSItem.cpp
+++ b/src/plugin/BodyROSItem.cpp
@@ -152,103 +152,104 @@ void BodyROSItem::createSensors(BodyPtr body)
     force_sensor_publishers_.reserve(forceSensors_.size());
     force_sensor_switch_servers_.clear();
     force_sensor_switch_servers_.reserve(forceSensors_.size());
-    for (size_t i=0; i < forceSensors_.size(); ++i) {
-        if (ForceSensor* sensor = forceSensors_[i]) {
-            std::string name = sensor->name();
-            std::replace(name.begin(), name.end(), '-', '_');
-            force_sensor_publishers_.push_back(
-                rosnode_->advertise<geometry_msgs::WrenchStamped>(name, 1));
-            sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateForceSensor,
-                                                          this, sensor, force_sensor_publishers_[i]));
-            boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
-                = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
-            force_sensor_switch_servers_.push_back(
-                rosnode_->advertiseService(name + "/set_enabled", requestCallback));
-            ROS_INFO("Create force sensor %s", sensor->name().c_str());
-        }
+    for (ForceSensorPtr sensor : forceSensors_) {
+        std::string name = sensor->name();
+        std::replace(name.begin(), name.end(), '-', '_');
+        const ros::Publisher publisher
+            = rosnode_->advertise<geometry_msgs::WrenchStamped>(name, 1);
+        sensor->sigStateChanged().connect(
+            boost::bind(&BodyROSItem::updateForceSensor,
+                        this, sensor, publisher));
+        force_sensor_publishers_.push_back(publisher);
+        boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
+            = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
+        force_sensor_switch_servers_.push_back(
+            rosnode_->advertiseService(name + "/set_enabled", requestCallback));
+        ROS_INFO("Create force sensor %s", sensor->name().c_str());
     }
     rate_gyro_sensor_publishers_.clear();
     rate_gyro_sensor_publishers_.reserve(gyroSensors_.size());
     rate_gyro_sensor_switch_servers_.clear();
     rate_gyro_sensor_switch_servers_.reserve(gyroSensors_.size());
-    for (size_t i=0; i < gyroSensors_.size(); ++i) {
-        if (RateGyroSensor* sensor = gyroSensors_[i]) {
-            std::string name = sensor->name();
-            std::replace(name.begin(), name.end(), '-', '_');
-            rate_gyro_sensor_publishers_.push_back(
-                rosnode_->advertise<sensor_msgs::Imu>(name, 1));
-            sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateRateGyroSensor,
-                                                          this, sensor, rate_gyro_sensor_publishers_[i]));
-            boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
-                = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
-            rate_gyro_sensor_switch_servers_.push_back(
-                rosnode_->advertiseService(name + "/set_enabled", requestCallback));
-            ROS_INFO("Create gyro sensor %s", sensor->name().c_str());
-        }
+    for (RateGyroSensorPtr sensor : gyroSensors_) {
+        std::string name = sensor->name();
+        std::replace(name.begin(), name.end(), '-', '_');
+        const ros::Publisher publisher
+            = rosnode_->advertise<sensor_msgs::Imu>(name, 1);
+        sensor->sigStateChanged().connect(
+            boost::bind(&BodyROSItem::updateRateGyroSensor,
+                        this, sensor, publisher));
+        rate_gyro_sensor_publishers_.push_back(publisher);
+        boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
+            = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
+        rate_gyro_sensor_switch_servers_.push_back(
+            rosnode_->advertiseService(name + "/set_enabled", requestCallback));
+        ROS_INFO("Create gyro sensor %s", sensor->name().c_str());
     }
     accel_sensor_publishers_.clear();
     accel_sensor_publishers_.reserve(accelSensors_.size());
     accel_sensor_switch_servers_.clear();
     accel_sensor_switch_servers_.reserve(accelSensors_.size());
-    for (size_t i=0; i < accelSensors_.size(); ++i) {
-        if (AccelerationSensor* sensor = accelSensors_[i]) {
-            std::string name = sensor->name();
-            std::replace(name.begin(), name.end(), '-', '_');
-            accel_sensor_publishers_.push_back(
-                rosnode_->advertise<sensor_msgs::Imu>(name, 1));
-            sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateAccelSensor,
-                                                          this, sensor, accel_sensor_publishers_[i]));
-            boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
-                = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
-            accel_sensor_switch_servers_.push_back(
-                rosnode_->advertiseService(name + "/set_enabled", requestCallback));
-            ROS_INFO("Create accel sensor %s", sensor->name().c_str());
-        }
+    for (AccelerationSensorPtr sensor : accelSensors_) {
+        std::string name = sensor->name();
+        std::replace(name.begin(), name.end(), '-', '_');
+        const ros::Publisher publisher
+            = rosnode_->advertise<sensor_msgs::Imu>(name, 1);
+        sensor->sigStateChanged().connect(
+            boost::bind(&BodyROSItem::updateAccelSensor,
+                        this, sensor, publisher));
+        accel_sensor_publishers_.push_back(publisher);
+        boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
+            = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
+        accel_sensor_switch_servers_.push_back(
+            rosnode_->advertiseService(name + "/set_enabled", requestCallback));
+        ROS_INFO("Create accel sensor %s", sensor->name().c_str());
     }
     image_transport::ImageTransport it(*rosnode_);
     vision_sensor_publishers_.clear();
     vision_sensor_publishers_.reserve(visionSensors_.size());
     vision_sensor_switch_servers_.clear();
     vision_sensor_switch_servers_.reserve(visionSensors_.size());
-    for (size_t i=0; i < visionSensors_.size(); ++i) {
-        if (Camera* sensor = visionSensors_[i]) {
-            std::string name = sensor->name();
-            std::replace(name.begin(), name.end(), '-', '_');
-            vision_sensor_publishers_.push_back(
-                it.advertise(name + "/image_raw", 1));
-            sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateVisionSensor,
-                                                          this, sensor, vision_sensor_publishers_[i]));
-            boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
-                = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
-            vision_sensor_switch_servers_.push_back(
-                rosnode_->advertiseService(name + "/set_enabled", requestCallback));
-            ROS_INFO("Create RGB camera %s (%f Hz)", sensor->name().c_str(), sensor->frameRate());
-        }
+    for (CameraPtr sensor : visionSensors_) {
+        std::string name = sensor->name();
+        std::replace(name.begin(), name.end(), '-', '_');
+        const image_transport::Publisher publisher
+            = it.advertise(name + "/image_raw", 1);
+        sensor->sigStateChanged().connect(
+            boost::bind(&BodyROSItem::updateVisionSensor,
+                        this, sensor, publisher));
+        vision_sensor_publishers_.push_back(publisher);
+        boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
+            = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
+        vision_sensor_switch_servers_.push_back(
+            rosnode_->advertiseService(name + "/set_enabled", requestCallback));
+        ROS_INFO("Create RGB camera %s (%f Hz)",
+                 sensor->name().c_str(), sensor->frameRate());
     }
     range_vision_sensor_publishers_.clear();
     range_vision_sensor_publishers_.reserve(rangeVisionSensors_.size());
     range_vision_sensor_switch_servers_.clear();
     range_vision_sensor_switch_servers_.reserve(rangeVisionSensors_.size());
-    for (size_t i=0; i < rangeVisionSensors_.size(); ++i) {
-        if (RangeCamera* sensor = rangeVisionSensors_[i]) {
-            std::string name = sensor->name();
-            std::replace(name.begin(), name.end(), '-', '_');
-            range_vision_sensor_publishers_.push_back(
-                rosnode_->advertise<sensor_msgs::PointCloud2>(name + "/point_cloud", 1));
-            sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateRangeVisionSensor,
-                                                          this, sensor, range_vision_sensor_publishers_[i]));
-            // adds a server only for the camera whose type is COLOR_DEPTH or POINT_CLOUD.
-            // Without this exception, a new service server may be a duplicate
-            // of one added to 'vision_sensor_switch_servers_'.
-            if (sensor->imageType() == Camera::NO_IMAGE) {
-                boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
-                    = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
-                range_vision_sensor_switch_servers_.push_back(
-                    rosnode_->advertiseService(name + "/set_enabled", requestCallback));
-                ROS_INFO("Create depth camera %s (%f Hz)", sensor->name().c_str(), sensor->frameRate());
-            } else {
-                ROS_INFO("Create RGBD camera %s (%f Hz)", sensor->name().c_str(), sensor->frameRate());
-            }
+    for (RangeCameraPtr sensor : rangeVisionSensors_) {
+        std::string name = sensor->name();
+        std::replace(name.begin(), name.end(), '-', '_');
+        const ros::Publisher publisher = rosnode_->advertise<
+            sensor_msgs::PointCloud2>(name + "/point_cloud", 1);
+        sensor->sigStateChanged().connect(
+            boost::bind(&BodyROSItem::updateRangeVisionSensor,
+                        this, sensor, publisher));
+        range_vision_sensor_publishers_.push_back(publisher);
+        // adds a server only for the camera whose type is COLOR_DEPTH or POINT_CLOUD.
+        // Without this exception, a new service server may be a duplicate
+        // of one added to 'vision_sensor_switch_servers_'.
+        if (sensor->imageType() == Camera::NO_IMAGE) {
+            boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
+                = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
+            range_vision_sensor_switch_servers_.push_back(
+                rosnode_->advertiseService(name + "/set_enabled", requestCallback));
+            ROS_INFO("Create depth camera %s (%f Hz)", sensor->name().c_str(), sensor->frameRate());
+        } else {
+            ROS_INFO("Create RGBD camera %s (%f Hz)", sensor->name().c_str(), sensor->frameRate());
         }
     }
     range_sensor_publishers_.clear();
@@ -259,34 +260,37 @@ void BodyROSItem::createSensors(BodyPtr body)
     range_sensor_pc_publishers_.reserve(rangeSensors_.size());
     range_sensor_pc_switch_servers_.clear();
     range_sensor_pc_switch_servers_.reserve(rangeSensors_.size());
-    for (size_t i=0; i < rangeSensors_.size(); ++i) {
-        if (RangeSensor* sensor = rangeSensors_[i]) {
-            if(sensor->numPitchSamples() > 1){
-                std::string name = sensor->name();
-                std::replace(name.begin(), name.end(), '-', '_');
-                range_sensor_pc_publishers_.push_back(
-                    rosnode_->advertise<sensor_msgs::PointCloud>(name + "/point_cloud", 1));
-                sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::update3DRangeSensor,
-                                                              this, sensor, range_sensor_pc_publishers_[i]));
-                boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
-                    = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
-                range_sensor_pc_switch_servers_.push_back(
-                    rosnode_->advertiseService(name + "/set_enabled", requestCallback));
-                ROS_DEBUG("Create 3d range sensor %s (%f Hz)", sensor->name().c_str(), sensor->scanRate());
-            }
-            else{
-                std::string name = sensor->name();
-                std::replace(name.begin(), name.end(), '-', '_');
-                range_sensor_publishers_.push_back(
-                    rosnode_->advertise<sensor_msgs::LaserScan>(name + "/scan", 1));
-                sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateRangeSensor,
-                                                              this, sensor, range_sensor_publishers_[i]));
-                boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
-                    = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
-                range_sensor_switch_servers_.push_back(
-                    rosnode_->advertiseService(name + "/set_enabled", requestCallback));
-                ROS_DEBUG("Create 2d range sensor %s (%f Hz)", sensor->name().c_str(), sensor->scanRate());
-            }
+    for (RangeSensorPtr sensor : rangeSensors_) {
+        if (sensor->numPitchSamples() > 1) {
+            std::string name = sensor->name();
+            std::replace(name.begin(), name.end(), '-', '_');
+            const ros::Publisher publisher = rosnode_->advertise<
+                sensor_msgs::PointCloud>(name + "/point_cloud", 1);
+            sensor->sigStateChanged().connect(
+                boost::bind(&BodyROSItem::update3DRangeSensor,
+                            this, sensor, publisher));
+            range_sensor_pc_publishers_.push_back(publisher);
+            boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
+                = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
+            range_sensor_pc_switch_servers_.push_back(
+                rosnode_->advertiseService(name + "/set_enabled", requestCallback));
+            ROS_INFO("Create 3d range sensor %s (%f Hz)",
+                     sensor->name().c_str(), sensor->scanRate());
+        } else {
+            std::string name = sensor->name();
+            std::replace(name.begin(), name.end(), '-', '_');
+            const ros::Publisher publisher
+                = rosnode_->advertise<sensor_msgs::LaserScan>(name + "/scan", 1);
+            sensor->sigStateChanged().connect(
+                boost::bind(&BodyROSItem::updateRangeSensor,
+                            this, sensor, publisher));
+            range_sensor_publishers_.push_back(publisher);
+            boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
+                = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
+            range_sensor_switch_servers_.push_back(
+                rosnode_->advertiseService(name + "/set_enabled", requestCallback));
+            ROS_INFO("Create 2d range sensor %s (%f Hz)",
+                     sensor->name().c_str(), sensor->scanRate());
         }
     }
 }

--- a/src/plugin/BodyROSItem.cpp
+++ b/src/plugin/BodyROSItem.cpp
@@ -148,14 +148,16 @@ void BodyROSItem::createSensors(BodyPtr body)
         }
     }
 
-    force_sensor_publishers_.resize(forceSensors_.size());
+    force_sensor_publishers_.clear();
+    force_sensor_publishers_.reserve(forceSensors_.size());
     force_sensor_switch_servers_.clear();
     force_sensor_switch_servers_.reserve(forceSensors_.size());
     for (size_t i=0; i < forceSensors_.size(); ++i) {
         if (ForceSensor* sensor = forceSensors_[i]) {
             std::string name = sensor->name();
             std::replace(name.begin(), name.end(), '-', '_');
-            force_sensor_publishers_[i] = rosnode_->advertise<geometry_msgs::WrenchStamped>(name, 1);
+            force_sensor_publishers_.push_back(
+                rosnode_->advertise<geometry_msgs::WrenchStamped>(name, 1));
             sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateForceSensor,
                                                           this, sensor, force_sensor_publishers_[i]));
             boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
@@ -165,14 +167,16 @@ void BodyROSItem::createSensors(BodyPtr body)
             ROS_INFO("Create force sensor %s", sensor->name().c_str());
         }
     }
-    rate_gyro_sensor_publishers_.resize(gyroSensors_.size());
+    rate_gyro_sensor_publishers_.clear();
+    rate_gyro_sensor_publishers_.reserve(gyroSensors_.size());
     rate_gyro_sensor_switch_servers_.clear();
     rate_gyro_sensor_switch_servers_.reserve(gyroSensors_.size());
     for (size_t i=0; i < gyroSensors_.size(); ++i) {
         if (RateGyroSensor* sensor = gyroSensors_[i]) {
             std::string name = sensor->name();
             std::replace(name.begin(), name.end(), '-', '_');
-            rate_gyro_sensor_publishers_[i] = rosnode_->advertise<sensor_msgs::Imu>(name, 1);
+            rate_gyro_sensor_publishers_.push_back(
+                rosnode_->advertise<sensor_msgs::Imu>(name, 1));
             sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateRateGyroSensor,
                                                           this, sensor, rate_gyro_sensor_publishers_[i]));
             boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
@@ -182,14 +186,16 @@ void BodyROSItem::createSensors(BodyPtr body)
             ROS_INFO("Create gyro sensor %s", sensor->name().c_str());
         }
     }
-    accel_sensor_publishers_.resize(accelSensors_.size());
+    accel_sensor_publishers_.clear();
+    accel_sensor_publishers_.reserve(accelSensors_.size());
     accel_sensor_switch_servers_.clear();
     accel_sensor_switch_servers_.reserve(accelSensors_.size());
     for (size_t i=0; i < accelSensors_.size(); ++i) {
         if (AccelerationSensor* sensor = accelSensors_[i]) {
             std::string name = sensor->name();
             std::replace(name.begin(), name.end(), '-', '_');
-            accel_sensor_publishers_[i] = rosnode_->advertise<sensor_msgs::Imu>(name, 1);
+            accel_sensor_publishers_.push_back(
+                rosnode_->advertise<sensor_msgs::Imu>(name, 1));
             sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateAccelSensor,
                                                           this, sensor, accel_sensor_publishers_[i]));
             boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
@@ -200,14 +206,16 @@ void BodyROSItem::createSensors(BodyPtr body)
         }
     }
     image_transport::ImageTransport it(*rosnode_);
-    vision_sensor_publishers_.resize(visionSensors_.size());
+    vision_sensor_publishers_.clear();
+    vision_sensor_publishers_.reserve(visionSensors_.size());
     vision_sensor_switch_servers_.clear();
     vision_sensor_switch_servers_.reserve(visionSensors_.size());
     for (size_t i=0; i < visionSensors_.size(); ++i) {
         if (Camera* sensor = visionSensors_[i]) {
             std::string name = sensor->name();
             std::replace(name.begin(), name.end(), '-', '_');
-            vision_sensor_publishers_[i] = it.advertise(name + "/image_raw", 1);
+            vision_sensor_publishers_.push_back(
+                it.advertise(name + "/image_raw", 1));
             sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateVisionSensor,
                                                           this, sensor, vision_sensor_publishers_[i]));
             boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
@@ -217,14 +225,16 @@ void BodyROSItem::createSensors(BodyPtr body)
             ROS_INFO("Create RGB camera %s (%f Hz)", sensor->name().c_str(), sensor->frameRate());
         }
     }
-    range_vision_sensor_publishers_.resize(rangeVisionSensors_.size());
+    range_vision_sensor_publishers_.clear();
+    range_vision_sensor_publishers_.reserve(rangeVisionSensors_.size());
     range_vision_sensor_switch_servers_.clear();
     range_vision_sensor_switch_servers_.reserve(rangeVisionSensors_.size());
     for (size_t i=0; i < rangeVisionSensors_.size(); ++i) {
         if (RangeCamera* sensor = rangeVisionSensors_[i]) {
             std::string name = sensor->name();
             std::replace(name.begin(), name.end(), '-', '_');
-            range_vision_sensor_publishers_[i] = rosnode_->advertise<sensor_msgs::PointCloud2>(name + "/point_cloud", 1);
+            range_vision_sensor_publishers_.push_back(
+                rosnode_->advertise<sensor_msgs::PointCloud2>(name + "/point_cloud", 1));
             sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateRangeVisionSensor,
                                                           this, sensor, range_vision_sensor_publishers_[i]));
             // adds a server only for the camera whose type is COLOR_DEPTH or POINT_CLOUD.
@@ -241,10 +251,12 @@ void BodyROSItem::createSensors(BodyPtr body)
             }
         }
     }
-    range_sensor_publishers_.resize(rangeSensors_.size());
+    range_sensor_publishers_.clear();
+    range_sensor_publishers_.reserve(rangeSensors_.size());
     range_sensor_switch_servers_.clear();
     range_sensor_switch_servers_.reserve(rangeSensors_.size());
-    range_sensor_pc_publishers_.resize(rangeSensors_.size());
+    range_sensor_pc_publishers_.clear();
+    range_sensor_pc_publishers_.reserve(rangeSensors_.size());
     range_sensor_pc_switch_servers_.clear();
     range_sensor_pc_switch_servers_.reserve(rangeSensors_.size());
     for (size_t i=0; i < rangeSensors_.size(); ++i) {
@@ -252,7 +264,8 @@ void BodyROSItem::createSensors(BodyPtr body)
             if(sensor->numPitchSamples() > 1){
                 std::string name = sensor->name();
                 std::replace(name.begin(), name.end(), '-', '_');
-                range_sensor_pc_publishers_[i] = rosnode_->advertise<sensor_msgs::PointCloud>(name + "/point_cloud", 1);
+                range_sensor_pc_publishers_.push_back(
+                    rosnode_->advertise<sensor_msgs::PointCloud>(name + "/point_cloud", 1));
                 sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::update3DRangeSensor,
                                                               this, sensor, range_sensor_pc_publishers_[i]));
                 boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
@@ -264,7 +277,8 @@ void BodyROSItem::createSensors(BodyPtr body)
             else{
                 std::string name = sensor->name();
                 std::replace(name.begin(), name.end(), '-', '_');
-                range_sensor_publishers_[i] = rosnode_->advertise<sensor_msgs::LaserScan>(name + "/scan", 1);
+                range_sensor_publishers_.push_back(
+                    rosnode_->advertise<sensor_msgs::LaserScan>(name + "/scan", 1));
                 sensor->sigStateChanged().connect(boost::bind(&BodyROSItem::updateRangeSensor,
                                                               this, sensor, range_sensor_publishers_[i]));
                 boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
@@ -273,7 +287,7 @@ void BodyROSItem::createSensors(BodyPtr body)
                     rosnode_->advertiseService(name + "/set_enabled", requestCallback));
                 ROS_DEBUG("Create 2d range sensor %s (%f Hz)", sensor->name().c_str(), sensor->scanRate());
             }
-        } 
+        }
     }
 }
 

--- a/src/plugin/BodyROSItem.h
+++ b/src/plugin/BodyROSItem.h
@@ -112,13 +112,20 @@ private:
     std::vector<ros::ServiceServer> range_sensor_switch_servers_;
     std::vector<ros::ServiceServer> range_sensor_pc_switch_servers_;
 
-    void updateForceSensor(ForceSensor* sensor, ros::Publisher& publisher);
-    void updateRateGyroSensor(RateGyroSensor* sensor, ros::Publisher& publisher);
-    void updateAccelSensor(AccelerationSensor* sensor, ros::Publisher& publisher);
-    void updateVisionSensor(Camera* sensor, image_transport::Publisher& publisher);
-    void updateRangeVisionSensor(RangeCamera* sensor, ros::Publisher& publisher);
-    void updateRangeSensor(RangeSensor* sensor, ros::Publisher& publisher);
-    void update3DRangeSensor(RangeSensor* sensor, ros::Publisher& publisher);
+    void updateForceSensor(const ForceSensorPtr& sensor,
+                           const ros::Publisher& publisher);
+    void updateRateGyroSensor(const RateGyroSensorPtr& sensor,
+                              const ros::Publisher& publisher);
+    void updateAccelSensor(const AccelerationSensorPtr& sensor,
+                           const ros::Publisher& publisher);
+    void updateVisionSensor(const CameraPtr& sensor,
+                            const image_transport::Publisher& publisher);
+    void updateRangeVisionSensor(const RangeCameraPtr& sensor,
+                                 const ros::Publisher& publisher);
+    void updateRangeSensor(const RangeSensorPtr& sensor,
+                           const ros::Publisher& publisher);
+    void update3DRangeSensor(const RangeSensorPtr& sensor,
+                             const ros::Publisher& publisher);
 
     bool switchDevice(std_srvs::SetBoolRequest &request,
                       std_srvs::SetBoolResponse &response,


### PR DESCRIPTION
Assigning elements after resizing a vector is generally redundant: resizing calls the constructor of ros::Publisher for N times by default, but all constructed objects are discarded by the assigns. 

This PR proposes to use pairs of `reserve` and `push_back` instead. Improvement of process efficiency is expected.