### PR TITLE
Enable BodyROSItem to switch devices via rosservice

### DIFF
--- a/src/plugin/BodyROSItem.cpp
+++ b/src/plugin/BodyROSItem.cpp
@@ -161,7 +161,7 @@ void BodyROSItem::createSensors(BodyPtr body)
             boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
                 = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
             force_sensor_switch_servers_.push_back(
-                rosnode_->advertiseService(name + "/switch", requestCallback));
+                rosnode_->advertiseService(name + "/set_enabled", requestCallback));
             ROS_INFO("Create force sensor %s", sensor->name().c_str());
         }
     }
@@ -178,7 +178,7 @@ void BodyROSItem::createSensors(BodyPtr body)
             boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
                 = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
             rate_gyro_sensor_switch_servers_.push_back(
-                rosnode_->advertiseService(name + "/switch", requestCallback));
+                rosnode_->advertiseService(name + "/set_enabled", requestCallback));
             ROS_INFO("Create gyro sensor %s", sensor->name().c_str());
         }
     }
@@ -195,7 +195,7 @@ void BodyROSItem::createSensors(BodyPtr body)
             boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
                 = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
             accel_sensor_switch_servers_.push_back(
-                rosnode_->advertiseService(name + "/switch", requestCallback));
+                rosnode_->advertiseService(name + "/set_enabled", requestCallback));
             ROS_INFO("Create accel sensor %s", sensor->name().c_str());
         }
     }
@@ -213,7 +213,7 @@ void BodyROSItem::createSensors(BodyPtr body)
             boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
                 = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
             vision_sensor_switch_servers_.push_back(
-                rosnode_->advertiseService(name + "/switch", requestCallback));
+                rosnode_->advertiseService(name + "/set_enabled", requestCallback));
             ROS_INFO("Create RGB camera %s (%f Hz)", sensor->name().c_str(), sensor->frameRate());
         }
     }
@@ -234,7 +234,7 @@ void BodyROSItem::createSensors(BodyPtr body)
                 boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
                     = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
                 range_vision_sensor_switch_servers_.push_back(
-                    rosnode_->advertiseService(name + "/switch", requestCallback));
+                    rosnode_->advertiseService(name + "/set_enabled", requestCallback));
                 ROS_INFO("Create depth camera %s (%f Hz)", sensor->name().c_str(), sensor->frameRate());
             } else {
                 ROS_INFO("Create RGBD camera %s (%f Hz)", sensor->name().c_str(), sensor->frameRate());
@@ -258,7 +258,7 @@ void BodyROSItem::createSensors(BodyPtr body)
                 boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
                     = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
                 range_sensor_pc_switch_servers_.push_back(
-                    rosnode_->advertiseService(name + "/switch", requestCallback));
+                    rosnode_->advertiseService(name + "/set_enabled", requestCallback));
                 ROS_DEBUG("Create 3d range sensor %s (%f Hz)", sensor->name().c_str(), sensor->scanRate());
             }
             else{
@@ -270,7 +270,7 @@ void BodyROSItem::createSensors(BodyPtr body)
                 boost::function<bool (std_srvs::SetBoolRequest&, std_srvs::SetBoolResponse&)> requestCallback
                     = boost::bind(&BodyROSItem::switchDevice, this, _1, _2, sensor);
                 range_sensor_switch_servers_.push_back(
-                    rosnode_->advertiseService(name + "/switch", requestCallback));
+                    rosnode_->advertiseService(name + "/set_enabled", requestCallback));
                 ROS_DEBUG("Create 2d range sensor %s (%f Hz)", sensor->name().c_str(), sensor->scanRate());
             }
         } 

--- a/src/plugin/BodyROSItem.h
+++ b/src/plugin/BodyROSItem.h
@@ -20,11 +20,14 @@
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/LaserScan.h>
 #include <geometry_msgs/WrenchStamped.h>
+#include <std_srvs/SetBool.h>
 
 #include <image_transport/image_transport.h>
 
-#include <vector>
 #include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "exportdecl.h"
 
@@ -101,6 +104,14 @@ private:
     std::vector<ros::Publisher> range_sensor_publishers_;
     std::vector<ros::Publisher> range_sensor_pc_publishers_;
 
+    std::vector<ros::ServiceServer> force_sensor_switch_servers_;
+    std::vector<ros::ServiceServer> rate_gyro_sensor_switch_servers_;
+    std::vector<ros::ServiceServer> accel_sensor_switch_servers_;
+    std::vector<ros::ServiceServer> vision_sensor_switch_servers_;
+    std::vector<ros::ServiceServer> range_vision_sensor_switch_servers_;
+    std::vector<ros::ServiceServer> range_sensor_switch_servers_;
+    std::vector<ros::ServiceServer> range_sensor_pc_switch_servers_;
+
     void updateForceSensor(ForceSensor* sensor, ros::Publisher& publisher);
     void updateRateGyroSensor(RateGyroSensor* sensor, ros::Publisher& publisher);
     void updateAccelSensor(AccelerationSensor* sensor, ros::Publisher& publisher);
@@ -108,6 +119,10 @@ private:
     void updateRangeVisionSensor(RangeCamera* sensor, ros::Publisher& publisher);
     void updateRangeSensor(RangeSensor* sensor, ros::Publisher& publisher);
     void update3DRangeSensor(RangeSensor* sensor, ros::Publisher& publisher);
+
+    bool switchDevice(std_srvs::SetBoolRequest &request,
+                      std_srvs::SetBoolResponse &response,
+                      Device* sensor);
 
     /**
       @brief Stop publish.


### PR DESCRIPTION
This PR provides a function discussed in [Discourse](https://discourse.choreonoid.org/t/ros/430/7).

- We can turn on/off sensors via rosservice.
- `std_srvs::SetBool` type is used.
- True and False correspond to ON and OFF, respectively.
- Initial states of sensors specified in model files are not changed, until BodyROSItem receives a change request.

Each service name is currently set to `device_name/switch`. This should be discussed.