### PR TITLE
Set /use_sim_time rosparam in a launch file to use simulator time

### DIFF
--- a/launch/choreonoid.launch
+++ b/launch/choreonoid.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="choreonoid_arg" default=""/>
+  <param name="/use_sim_time" value="true"/>
   <node name="choreonoid" pkg="choreonoid_ros" type="choreonoid"
         args="$(arg choreonoid_arg)" output="screen"/>
 </launch>


### PR DESCRIPTION
Setting a rosparam named `/use_sim_time` is required to use simulation time in whole of ROS framework.
`/clock` topic is published from WorldROS, but it does not work without this parameter.

Please see http://wiki.ros.org/Clock for more detail.