### PR TITLE
Fix link search with joint names

### DIFF
--- a/src/plugin/RobotHWCnoid.cpp
+++ b/src/plugin/RobotHWCnoid.cpp
@@ -89,7 +89,7 @@ bool RobotHWCnoid::initSim(const ros::NodeHandle& nh, cnoid::ControllerIO* args)
         jointNames[i] = transmission[i].joints_[0].name_;
 
         // Get cnoid::Link //
-        Link* link = io->body()->link(jointNames[i].c_str());
+        Link* link = io->body()->joint(jointNames[i].c_str());
         if(!link){
             mv->putln(
                 format(_("This robot has a joint named \"{0}\" which is not in the choreonoid model."),


### PR DESCRIPTION
This PR resolves errors on link search in ros_control joint registration. Since joint names and link names are independent in some formats such as URDF, we need to use `joint(name)` function with joint names, instead of `link(name)`.