### PR TITLE
add propertiy: publishJointState for on/off publishing joint_state

### DIFF
--- a/src/plugin/BodyROSItem.h
+++ b/src/plugin/BodyROSItem.h
@@ -78,10 +78,13 @@ private:
     DeviceList<RangeSensor> rangeSensors_;
     double timeStep_;
 
+    /* properties */
+    bool jointStatePublication;
+    double jointStateUpdateRate;
+
     /* joint states */
     sensor_msgs::JointState joint_state_;
     ros::Publisher jointStatePublisher;
-    double jointStateUpdateRate;
     double jointStateUpdatePeriod;
     double jointStateLastUpdate;
 


### PR DESCRIPTION
By This PR, a user can stop to publish joint_state by BodyROSItem.
This PR do not change default behavior.

joint_state can be published using joint_state_controller through ros_control.
http://wiki.ros.org/joint_state_controller
