### PR TITLE
[BodyROS2] Use joint names for joint states surely

### DIFF
--- a/src/plugin/BodyROS2Item.cpp
+++ b/src/plugin/BodyROS2Item.cpp
@@ -120,7 +120,7 @@ bool BodyROS2Item::start()
     for (size_t i = 0; i < body()->numAllJoints(); i++) {
         Link *joint = body()->joint(i);
 
-        jointState.name[i] = joint->name();
+        jointState.name[i] = joint->jointName();
         jointState.position[i] = joint->q();
         jointState.velocity[i] = joint->dq();
         jointState.effort[i] = joint->u();


### PR DESCRIPTION
This PR fixes joint names used in joint states.

Note that `name()` function returns not the joint name but the link name in general.