### PR TITLE
Fix installation conditions of 'launch' files with catkin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,14 @@ if(DEFINED ENV{ROS_VERSION})
     # For ros_control
     install(FILES plugins.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-    install(DIRECTORY launch
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-      USE_SOURCE_PERMISSIONS
-    )
+    # Install `launch` dir. only if `--install` option is set in catkin config
+    if(${CMAKE_INSTALL_PREFIX} MATCHES .*/install)
+      install(DIRECTORY launch
+          DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+          USE_SOURCE_PERMISSIONS
+          PATTERN "ros2" EXCLUDE
+        )
+    endif()
   elseif($ENV{ROS_VERSION} EQUAL 2)
     ament_package()
 


### PR DESCRIPTION
This PR resolves #22 .

To guarantee the requirements discussed in #16 , this PR adds an additional condition to install the `launch` directory: `choreonoid_ros` installs the directory only if the destination path ends with `install`, such as `~/catkin_ws/install`.

In fact, this is an ad hoc bug fix, but I don't have any other ideas at the moment.

FYI: the following document provides the list of variables we can utilise in CMake:
http://docs.ros.org/en/melodic/api/catkin/html/user_guide/variables.html
