### PR TITLE
Add dependency on ament_index_cpp to resolve build error in ROS 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ if(DEFINED ENV{ROS_VERSION})
     find_package(
       ament_cmake REQUIRED COMPONENTS
       rclcpp
+      ament_index_cpp
     )
   endif()
 endif()

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <depend condition="$ROS_VERSION == 1">joint_limits_interface</depend>
   <depend condition="$ROS_VERSION == 1">transmission_interface</depend>
   <depend condition="$ROS_VERSION == 1">urdf</depend>
+  <depend condition="$ROS_VERSION == 2">ament_index_cpp</depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">cmake</build_type>

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -8,7 +8,7 @@ if(DEFINED ENV{ROS_VERSION})
     install(TARGETS ${target} RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
   elseif($ENV{ROS_VERSION} EQUAL 2)
     add_executable(${target} choreonoid_ros2.cpp)
-    ament_target_dependencies(${target} rclcpp std_msgs sensor_msgs image_transport)
+    ament_target_dependencies(${target} rclcpp ament_index_cpp std_msgs sensor_msgs image_transport)
     set_target_properties(${target} PROPERTIES OUTPUT_NAME choreonoid)
     target_link_libraries(${target} Choreonoid::CnoidBase)
     install(TARGETS ${target}


### PR DESCRIPTION
This PR adds a dependency on ament_index_cpp to the package to resolve a build error encountered in ROS 2.
The missing dependency was causing issues during the build process, specifically related to including headers from `ament_index_cpp`.
Adding this dependency ensures that the necessary components are available for successful compilation.

## Testing Environment
OS: Ubuntu 24.04 (Docker)
ROS 2: Jazzy

## Build Error Log
The following is the build error log that prompted this change:
```
Starting >>> choreonoid_ros
--- stderr: choreonoid_ros
/home/ubuntu/ws_cnoid/src/choreonoid_ros/src/node/choreonoid_ros2.cpp:1:10: fatal error: ament_index_cpp/get_package_prefix.hpp: No such file or directory
    1 | #include <ament_index_cpp/get_package_prefix.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [src/node/CMakeFiles/choreonoid.dir/build.make:76: src/node/CMakeFiles/choreonoid.dir/choreonoid_ros2.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:185: src/node/CMakeFiles/choreonoid.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
/home/ubuntu/ws_cnoid/src/choreonoid_ros/src/plugin/BodyROS2Item.cpp: In member function ‘void cnoid::BodyROS2Item::update3DRangeSensor(cnoid::RangeSensor*, rclcpp::Publisher<sensor_msgs::msg::PointCloud2_<std::allocator<void> > >::SharedPtr)’:
/home/ubuntu/ws_cnoid/src/choreonoid_ros/src/plugin/BodyROS2Item.cpp:681:22: warning: unused variable ‘sinPitchAngle’ [-Wunused-variable]
  681 |         const double sinPitchAngle = sin(pitchAngle);
      |                      ^~~~~~~~~~~~~
gmake: *** [Makefile:146: all] Error 2

```

## Changes
Updated package.xml and CMakeLists.txt to include ament_index_cpp as a dependency.

## Testing
Successfully built and tested the package with the new dependency included.
Verified that the build error is no longer present after the addition of the dependency.
